### PR TITLE
検索機能の追加

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -2,7 +2,7 @@ class TweetsController < ApplicationController
 
   # before_action :set_tweets, only: [:edit, :show] 今回は実装なし
 
-  before_action :move_to_index, except: [:index, :show]
+  before_action :move_to_index, except: [:index, :show, :search]
   # == new,create,edit,update,destoryは全てindex.html.erbにリダイレクトされる。
 
   def index
@@ -49,6 +49,10 @@ class TweetsController < ApplicationController
     # => 削除完了のビューへ。
   end
 
+  def search
+    @tweets = Tweet.search(params[:keyword])
+    # ここのパラメーターはform_withで設定した:keywordというキー。
+  end
 
   private
   # 他のクラスからアクセス出来ないようにする。

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,6 +2,17 @@ class Tweet < ApplicationRecord
   validates :text, presence: true
   belongs_to :user
   has_many :comments
+
+  def self.search(search) # 投稿を表示するメソッド
+
+    if search
+      Tweet.where( "text LIKE(?)", "#{search}" )
+    else
+      Tweet.all
+    end
+
+  end
+
 end
 
 # コントローラークラスでクラスメソッドであるcreateメソッドがTweetモデルに対して使えるのは
@@ -10,3 +21,7 @@ end
 
 # バリデーションはモデルクラスに記載。
 # このバリデーションの設定で空のツイートは登録不可能になった。
+
+# コントローラーはあくまでモデルの機能を利用し処理を呼ぶだけで、複雑な処理は組まない。
+
+# where => モデル.where(条件)のように引数部分に条件を指定することで、テーブル内の条件に一致したレコードのインスタンスを配列の形で取得できます。

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -1,3 +1,10 @@
+<%= form_with(url: search_tweets_path, local: true, method: :get, class: "search-form") do |form| %>
+  <%= form.text_field :keyword, placeholder: "投稿を検索する", class: "search-input" %>
+  <%= form.submit "検索", class: "search-btn" %>
+<% end %>
+
+<%# 投稿を検索するform_with。データを保存しないためモデルクラスのインスタンス設定は行わない。 %>
+
 <div class="contents row">
   <% @tweets.each do |tweet| %>
     <%= render partial: "tweet", locals: { tweet: tweet } %>

--- a/app/views/tweets/search.html.erb
+++ b/app/views/tweets/search.html.erb
@@ -1,0 +1,12 @@
+
+<%= form_with(url: search_tweets_path, local: true, method: :get, class: "search-form") do |form| %>
+  <%= form.text_field :keyword, placeholder: "投稿を検索する", class: "search-input" %>
+  <%= form.submit "検索", class: "search-btn" %>
+<% end %>
+<div class="contents row">
+  <% @tweets.each do |tweet| %>
+    <%= render partial: "tweet", locals: { tweet: tweet } %>
+  <% end %>
+</div>
+
+<%# searchアクションに対するビュー %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   # resources :tweets, only: [:index, :new, :create, :destroy, :edit, :update, :show] => リファクタリング後
   resources :tweets do
     resources :comments, only: :create
+    collection do
+      get 'search'
+    end
   end
   resources :users, only: :show
 end


### PR DESCRIPTION
# WHAT

ルーティングでtweets controllerのsearchアクションに遷移するように、ルーティングをcolletionを使い実装。
検索するビューはform_withにてできており、コメントのパラメーター( :keyword )をコントローラーでparamsとして処理。
searchアクションはTweetモデル内にロジックを記載。

``` Tweet.rb

  def self.search(search) # 投稿を表示するメソッド paramsを引数で受け取る。

    if search # 引数があったら
      Tweet.where( "text LIKE(?)", "#{search}" )
    else
      Tweet.all
    end

  end

```

